### PR TITLE
Add DuckDB integration test GitHub Action

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,0 +1,26 @@
+name: Integration Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test-duckdb:
+    name: Integration Tests (DuckDB)
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dbt-duckdb
+        run: pip install dbt-duckdb
+
+      - name: Run integration tests
+        run: bash scripts/run_integration_tests_duckdb.sh

--- a/scripts/run_integration_tests_duckdb.sh
+++ b/scripts/run_integration_tests_duckdb.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+INT_TESTS_DIR="$REPO_ROOT/integration_tests"
+
+echo "=== dbt-set-similarity Integration Tests (DuckDB) ==="
+echo ""
+
+mkdir -p "$REPO_ROOT/duckdb"
+
+cd "$INT_TESTS_DIR"
+
+echo "1. Installing dependencies..."
+dbt deps --profile integration_tests_duckdb
+
+echo ""
+echo "2. Loading seed data..."
+dbt seed --profile integration_tests_duckdb
+
+echo ""
+echo "3. Running dbt models..."
+dbt run --profile integration_tests_duckdb
+
+echo ""
+echo "4. Running tests..."
+dbt test --profile integration_tests_duckdb
+
+echo ""
+echo "=== All tests passed! ==="


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/integration-tests.yml` that triggers on push/PR to `main`
- Adds `scripts/run_integration_tests_duckdb.sh` that runs `dbt deps → seed → run → test` against DuckDB
- Mirrors the CI pattern used in `dbt-stat-test` and `dbt-orphan`

## Test plan

- [ ] Verify the GitHub Action triggers and passes on this PR
- [ ] All 4 coefficient tests (dice, jaccard, overlap, tversky) pass locally against DuckDB

🤖 Generated with [Claude Code](https://claude.com/claude-code)